### PR TITLE
Add CTFd-multi-question-plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 [submodule "CTFd_hash_crack_king"]
 	path = CTFd_hash_crack_king
 	url = https://github.com/jtylers/CTFd_hash_crack_king.git
+[submodule "CTFd-multi-question-plugin"]
+	path = CTFd-multi-question-plugin
+	url = https://github.com/tamuctf/CTFd-multi-question-plugin.git


### PR DESCRIPTION
Finally update the plugin we used for TAMUctf to work with v1.1.3. Also managed to fix a couple bugs that we had during the competition.