### PR TITLE
Added dropbox uploader plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -41,3 +41,6 @@
 [submodule "ctfd-event-countdown"]
 	path = ctfd-event-countdown
 	url = https://github.com/alokmenghrajani/ctfd-event-countdown.git
+[submodule "CTFd-dropbox-plugin"]
+	path = CTFd-dropbox-plugin
+	url = https://github.com/erseco/CTFd-dropbox-plugin.git


### PR DESCRIPTION
Add Dropbox uploader backend support to store files using Dropbox API. 

To use it you need to generate a
_oauth2 token_ following the [Dropbox API tutorial](https://www.dropbox.com/developers/documentation/python#tutorial), set it to the `DROPBOX_OAUTH2_TOKEN`  variable and set `UPLOAD_PROVIDER`  to `dropbox`

You can specify the `DROPBOX_ROOT_PATH`, by default will be /CTFd