### PR TITLE
Adding CTFTime API Endpoint

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -44,3 +44,6 @@
 [submodule "CTFd-dropbox-plugin"]
 	path = CTFd-dropbox-plugin
 	url = https://github.com/erseco/CTFd-dropbox-plugin.git
+[submodule "CTFd_CTFTime_endpoint"]
+	path = CTFd_CTFTime_endpoint
+	url = https://github.com/durkinza/CTFd_CTFTime_endpoint


### PR DESCRIPTION
This plugin creates a api endpoint that conforms to CTF Time's [scoreboard feed format](https://ctftime.org/json-scoreboard-feed) for Jeopardy-style CTFs.

Endpoing added at
`/api/v1/ctftime`

It should be noted that this plugin will show the name and scores of all visible challenges. This includes challenges that would normally be hidden until it's requirements have been fulfilled. 

Refrences Issue #22 