### PR TITLE
Adding team attributes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -44,3 +44,6 @@
 [submodule "CTFd-dropbox-plugin"]
 	path = CTFd-dropbox-plugin
 	url = https://github.com/erseco/CTFd-dropbox-plugin.git
+[submodule "CTFd_Team_Attributes"]
+	path = CTFd_Team_Attributes
+	url = https://github.com/durkinza/CTFd_Team_Attributes


### PR DESCRIPTION
This plugin gives the ctf administrators the ability to add additional attributes to teams. 
These attributes can be used by other plugins and/or by the ctf administrators themselves.

Examples of possible uses:
 - To receive additional information from each team that would not otherwise be supplied on the team's registration,
 - To share separate information to each team (such as providing a unique passcode to each team),
 - For administrators to keep private notes about each team (such as marking teams that have suspicious login activity)
 - For another plugin to store configuration information unique to each team.

The plugin is likely to be used as a "helper" for other plugins, but can be used independently.