### PR TITLE
Add CTFd_chat_notifier plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -44,3 +44,6 @@
 [submodule "CTFd-dropbox-plugin"]
 	path = CTFd-dropbox-plugin
 	url = https://github.com/erseco/CTFd-dropbox-plugin.git
+[submodule "CTFd_chat_notifier"]
+	path = CTFd_chat_notifier
+	url = https://github.com/krzys-h/CTFd_chat_notifier.git


### PR DESCRIPTION
This adds a plugin which allows sending notifications about solves and admin announcements to Slack, Discord or Telegram