### PR TITLE
Adding Split Scoreboard plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -44,3 +44,6 @@
 [submodule "CTFd-dropbox-plugin"]
 	path = CTFd-dropbox-plugin
 	url = https://github.com/erseco/CTFd-dropbox-plugin.git
+[submodule "CTFd_Split_Scoreboard"]
+	path = CTFd_Split_Scoreboard
+	url = https://github.com/durkinza/CTFd_Split_Scoreboard.git


### PR DESCRIPTION
This plugin splits the scoreboard based on a team field. 
This is useful for events that wish to rank players in seperate categories based on a team field or by the size of the teams.

This plugins also adds the custom scoreboard feature, which allows viewers to create custom rankings of the teams of their choice. 