### PR TITLE
Adds ctfd-solve-webhook-plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -53,3 +53,6 @@
 [submodule "CTFd-gdrive-plugin"]
 	path = CTFd-gdrive-plugin
 	url = https://github.com/TheArqsz/CTFd-gdrive-plugin
+[submodule "ctfd-solve-webhook-plugin"]
+	path = ctfd-solve-webhook-plugin
+	url = https://github.com/iosifache/ctfd-solve-webhook-plugin


### PR DESCRIPTION
Hi CTFd team,

I'm submitting this PR to add a new CTFd plugin for calling a custom webhook after a challenge is solved.

The newly linked repository includes:
- A configurable CTFd plugin that calls a specific webhook when the first `N` players solve a challenge;
- [A predefined webhook for sending Mattermost messages to a channel](https://github.com/iosifache/ctfd-solve-webhook-plugin/tree/main/webhooks/mattermost);
- [A Swagger definition that should be respected by the webhooks](https://github.com/iosifache/ctfd-solve-webhook-plugin/blob/main/webhooks/swagger.yaml);
- [A Docker Compose infrastructure for testing the webhooks and their integration with CTFd](https://github.com/iosifache/ctfd-solve-webhook-plugin/blob/main/docker-compose.yaml); and
- [An extensive documentation in `README.md`](https://github.com/iosifache/ctfd-solve-webhook-plugin/blob/main/README.md).

P.S.: Thank you for the time and effort you put into this open source CTF platform 🙏🏿!