### PR TITLE
Add ctfd-chall-manager plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -56,3 +56,6 @@
 [submodule "ctfd-solve-webhook-plugin"]
 	path = ctfd-solve-webhook-plugin
 	url = https://github.com/iosifache/ctfd-solve-webhook-plugin
+[submodule "ctfd-chall-manager"]
+	path = ctfd-chall-manager
+	url = https://github.com/ctfer-io/ctfd-chall-manager


### PR DESCRIPTION
Hi there! 

After several months of development and private alpha, [our](https://ctfer.io) plugin is now available to everyone in public beta! 

This plugin brings chall-manager to CTFd as a plugin to provide on-demand challenges for players, ratelimiting and flags per instance!  Many other features are available, so don't hesitate to use it and contribute [here](https://github.com/ctfer-io/ctfd-chall-manager) :confetti_ball: 

It is fully compatible with both user mode and the latest CTFd version :smile: 

Poke @PandatiX