### PR TITLE
add ctfd-modules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -71,3 +71,6 @@
 [submodule "ctfd-chall-manager"]
 	path = ctfd-chall-manager
 	url = https://github.com/ctfer-io/ctfd-chall-manager
+[submodule "ctfd-modules"]
+	path = ctfd-modules
+	url = https://github.com/caprinux/ctfd-modules/


### PR DESCRIPTION
> CTFd modules is a plugin that further categorizes challenges into modules. The main purpose of this is to better organize challenges which would be useful when CTFd is used as a training platform.

Hi CTFd team,

I'm submitting this PR to add a new CTFd plugin to categorize challenges into different modules.

This will be useful when CTFd is used as a training platforms as we can segregate challenges into modules and within each modules, have different topics (as categories).